### PR TITLE
Trim package description and add markdown placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "three-headed-dog",
   "version": "1.0.0",
-  "description": "| Stage | Repo (clone & `npm i`) | What it does | Why it fits | | ----- | ----- | ----- | ----- | | 1\\. Markdown → HTML | **markedjs/marked** | Fast, 100 % JS Markdown → HTML converter | One-liner in Node, no build chain needed [GitHub](https://github.com/markedjs/marked?utm_source=chatgpt.com) | | 2\\. Add SCORM runtime | **pipwerks/scorm-api-wrapper** | Drop the `scorm_api_wrapper.js` file next to each HTML page to satisfy LMS API calls | Zero config, industry-standard wrapper [GitHub](https://github.com/pipwerks/scorm-api-wrapper?utm_source=chatgpt.com) | | 3\\. Zip as SCORM | **lmihaidaniel/simple-scorm-packager** | CLI/JS lib that walks a folder, writes `imsmanifest.xml`, and outputs SCORM 1.2/2004 ZIP | No code if you use the CLI; scriptable if you want full automation [npm](https://www.npmjs.com/package/simple-scorm-packager?utm_source=chatgpt.com) |",
+  "description": "Minimal Node.js pipeline to convert Markdown to HTML, inject SCORM runtime, and package as SCORM 1.2 or IMS CC.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- shorten package.json description for better readability
- add a blank markdown README placeholder

## Testing
- `node build.js` *(fails: NOT IMPLEMENTED)*

------
https://chatgpt.com/codex/tasks/task_b_68771ce2075c8326911242595d9dafca