### PR TITLE
Fix IMSCC packCourse import

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const { marked } = require('marked');
 const pack = require('simple-scorm-packager');
-const { packageCourse: packCourse } = require('@openlearning/imscc-packager');
+let { packCourse, packageCourse } = require('@openlearning/imscc-packager');
+if (!packCourse && packageCourse) {
+  packCourse = packageCourse;
+}
 
 const COURSE_TITLE = 'Course';
 const VERSION = '1.2';


### PR DESCRIPTION
## Summary
- update build script to import `packCourse`
- fall back to legacy `packageCourse` when `packCourse` is unavailable

## Testing
- `node build.js`

------
https://chatgpt.com/codex/tasks/task_b_6877301ef868832681f71600019548b1